### PR TITLE
Fix issues with GetSmellsByDate

### DIFF
--- a/src/intent_handling/intent_resolver.py
+++ b/src/intent_handling/intent_resolver.py
@@ -1,7 +1,7 @@
 from src.intent_handling.cadocs_intent import CadocsIntents
 from src.intent_handling.tool_selector import ToolSelector
 from src.intent_handling.tools import CsDetectorTool
-
+from datetime import datetime
 # the Intent Resolver is used to handle the execution given a predicted intent
 class IntentResolver:
     def resolve_intent(self, intent, entities):
@@ -13,10 +13,16 @@ class IntentResolver:
                 tool = ToolSelector(CsDetectorTool())
                 # then we execute the selected tool with given entities
                 # here the date (if present) is set to the format requested by csDetector
-                if len(entities) > 2:
+                if len(entities) >= 2:
                     split_date = entities[1].split("/")
-                    entities[1] = ""+split_date[1]+"/"+split_date[0]+"/"+split_date[2]
-                
+                    # we conver the date to format '%Y-%m-%d'
+                    entities[1] = ""+split_date[2]+"/"+split_date[1]+"/"+split_date[0]
+                    # Convert to datetime object
+                    date_object = datetime.strptime(entities[1], '%Y/%m/%d')
+
+                    # Convert back to string in the desired format
+                    entities[1] = date_object.strftime('%Y-%m-%d')
+
                 results = tool.run(entities)
                 print("\n\n\nRESULT IN INTENT RESOLVER", results)
                 print("\n\n\n")

--- a/src/intent_handling/tools.py
+++ b/src/intent_handling/tools.py
@@ -12,8 +12,8 @@ class CsDetectorTool(Tool):
         print("\n\n\nSono in execute tool",data)
         print("\n\n\n")
         #if we have 2 entities (repo and date), we execute the tool with date parameter
-        if data.__len__() > 2:
-            req = requests.get(os.environ.get('CSDETECTOR_URL_GETSMELLS')+'?repo='+data[0]+'&pat='+os.environ.get('PAT',"")+"&date="+data[1])
+        if data.__len__() >= 2:
+            req = requests.get(os.environ.get('CSDETECTOR_URL_GETSMELLS')+'?repo='+data[0]+'&pat='+os.environ.get('PAT',"")+"&start="+data[1])
         else:
             req = requests.get(os.environ.get('CSDETECTOR_URL_GETSMELLS')+'?repo='+data[0]+'&pat='+os.environ.get('PAT',"")) #+'&user='+data[data.__len__()-1]+"&graphs=True"
         

--- a/src/service/cadocs_messages.py
+++ b/src/service/cadocs_messages.py
@@ -19,7 +19,7 @@ def build_cs_message(smells, entities, lang):
     elif lang == "it":
         text += f"Ciao 👋🏼\n"
 
-    if len(entities) > 2:
+    if len(entities) >= 2:
         if lang == "en":
             text += f"These are the community smells we were able to detect in the repository {entities[0]} starting from {entities[1]}:\n"
         elif lang == "it":


### PR DESCRIPTION
Fixes #2

La issue referenziata è #2 su GitHub (https://github.com/carlovend/CADOCS_II/issues/2).

Il problema risiedeva nell'uso scorretto dell'operatore >. Quando gli utenti richiedevano la funzione per ottenere smells per data, l'array delle entità conteneva almeno 2 voci. Tuttavia, nel codice, questo veniva sempre ignorato a causa della condizione if len(entities) > 2.

Inoltre, il formato della data fornita a csDetector è stato cambiato nel formato accettato, che è %Y-%m-%d.

Infine, il parametro GET nella richiesta URL a csDetector è stato aggiornato. Il parametro "date" è stato sostituito con "start" perché csDetector non utilizza "date" ma invece utilizza "start".

csDetector è stato anche corretto per funzionare con questa PR, si prega di utilizzare questa nuova versione su https://github.com/benedettoscala/csDetector.